### PR TITLE
Unique permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By default, a notification will be shown if the pushed data includes a `message`
 Optionally, you can also supply a `title`.
 
 ### Intents
-Sometimes simply displaying a drawer notification isn't enough. You might want to do 
+Sometimes simply displaying a drawer notification isn't enough. You might want to do
 something when it is clicked. Luckily, we thought of that too!
 
 There are two different ways to do such:
@@ -94,7 +94,7 @@ delegate.setDefaultIcon(R.drawable.ic_launcher);
 // the activity to open when the drawer notification is clicked, default: launch activity
 delegate.setDefaultActivity(CustomActivity.class);
 ```
- 
+
 Initialize with the delegate:
 ```java
 ShoveClient.initialize(this, "YOUR_GCM_APPLICATION_ID", delegate);
@@ -108,6 +108,13 @@ own delegate. Simply create a class that implements `com.myriadmobile.library.sh
 
 Usage
 -------
+Declare the custom permission in your Android Manifest file.
+```xml
+<permission
+		android:name="${applicationId}.permission.C2D_MESSAGE"
+		android:protectionLevel="signature" />
+	<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+```
 
 Documentation
 -------

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Declare the custom permission in your Android Manifest file.
 <permission
 		android:name="${applicationId}.permission.C2D_MESSAGE"
 		android:protectionLevel="signature" />
-	<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 ```
 
 Documentation

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.myriadmobile.library.shove.example">
 
+	<permission
+		android:name="${applicationId}.permission.C2D_MESSAGE"
+		android:protectionLevel="signature" />
+	<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+
     <application
         android:name=".ShoveApplication"
         android:allowBackup="true"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Thu Feb 19 15:49:17 CST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -6,11 +6,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
-    <permission
-        android:name="${applicationId}.permission.C2D_MESSAGE"
-        android:protectionLevel="signature" />
-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
-
     <application>
 
         <meta-data


### PR DESCRIPTION
The current custom permission declaration inside of the project appears to always be the same - I believe the applicationId used in the manifest is local to the lib/project, which always results in the same permission declaration below. 

When using Shove within multiple applications on the same device it can cause a duplicate permission failure or a 515 response from the Google Play Store.

![shove_permission_error](https://cloud.githubusercontent.com/assets/5649524/6277806/817b67f0-b857-11e4-98be-1e1ab401cf15.png)

> Starting in Android 5.0, the system enforces a new uniqueness restriction on custom permissions for apps that are signed with different keys. Now only one app on a device can define a given custom permission (as determined by its name), unless the other app defining the permission is signed with the same key. If the user tries to install an app with a duplicate custom permission and is not signed with the same key as the resident app that defines the permission, the system blocks the installation.

http://developer.android.com/about/versions/android-5.0-changes.html
