### PR TITLE
Modified dependencies to use new segmented Google Play Services packages

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -23,9 +23,12 @@ android {
 project.archivesBaseName = "shove-example-" + android.defaultConfig.versionName;
 
 dependencies {
-    compile 'com.google.android.gms:play-services:4.4.+'
+    // Dependencies required for Shove to function properly.
     compile 'com.android.support:support-v4:20.+'
-    compile project(':library')
+    compile 'com.google.android.gms:play-services-gcm:8.3.0+'
+
+    // Shove Library.
+    compile 'com.myriadmobile.library:shove:0.9.0'
 }
 
 if (project.hasProperty("shoveStoreFile") && project.hasProperty("shoveStorePassword") && project.hasProperty("shoveKeyAlias") && project.hasProperty("shoveKeyPassword")) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,7 +11,7 @@ android {
 }
 
 dependencies {
-    provided 'com.google.android.gms:play-services:+'
+    provided 'com.google.android.gms:play-services-gcm:8.3.0+'
     provided 'com.android.support:support-v4:+'
 }
 

--- a/library/src/main/java/com/myriadmobile/library/shove/ShoveClient.java
+++ b/library/src/main/java/com/myriadmobile/library/shove/ShoveClient.java
@@ -1,6 +1,5 @@
 package com.myriadmobile.library.shove;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;


### PR DESCRIPTION
using the *-gcm subset of Google Play Services to reduce dependency size for implementers.

modified the example Gradle file to pull the file from jcenter instead of including the project locally since that's what most people will need to see to get started.
